### PR TITLE
chore: update ben-manes gradle-versions plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   repositories {
     mavenCentral()
     google()
-    gradlePluginPortal()
+    //gradlePluginPortal()
     //mavenLocal()
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "7.1.2"
+agp = "7.3.1"
 bytebuddy = "1.12.10"
 composeCompiler = "1.3.0"
 javaTarget = "1.8"
@@ -67,4 +67,4 @@ plugin-grgit = { module = "org.ajoberstar.grgit:grgit-gradle", version = "5.0.0"
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.21.0" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.8.0" }
-plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
+plugin-versions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.44.0" }

--- a/paparazzi/build.gradle
+++ b/paparazzi/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   repositories {
     mavenCentral()
     google()
-    gradlePluginPortal()
+    //gradlePluginPortal()
     //mavenLocal()
   }
 


### PR DESCRIPTION
- subdependency contains not found xstream lib
- updated android-gradle-plugin to 7.3.1
- removed `gradlePluginPortal()` as it links to jcenter wich is down since ages